### PR TITLE
Fix for beforeCreate getting passed options object

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -68,7 +68,9 @@ var attachToUser = function (UserSchema, options) {
         if (options.usernameLowerCase) {
             user[options.usernameField] = user[options.usernameField].toLowerCase();
         }
-        next();
+        if (typeof(next) == 'function') {
+            next();
+        }
     };
     
     UserSchema.DAO.prototype.setPassword = function (password, cb) {


### PR DESCRIPTION
In some instances, `beforeCreate` is passed in an object for `next` instead of a function, and therefore `next()` will return an exception
