### PR TITLE
ensure that salt field is not null

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -26,7 +26,8 @@ var defaultAttachOptions = {
     missingFieldError: 'Field %s is not set',
     missingPasswordError: 'Password argument not set!',
     userExistsError: 'User already exists with %s',
-    activationError: 'Email activation required'
+    activationError: 'Email activation required',
+    noSaltValueStoredError: 'Authentication not possible. No salt value stored in db!'
 };
 
 // The default schema used when creating the User model
@@ -122,7 +123,13 @@ var attachToUser = function (UserSchema, options) {
 
     UserSchema.DAO.prototype.authenticate = function (password, cb) {
         var self = this;
-        // TODO: Fix callback and behavior to match passport
+
+        // prevent to throw error from crypto.pbkdf2
+        if (!this.get(options.saltField)) {
+            return cb(null, false, { message: options.noSaltValueStoredError });
+        }
+
+        // TODO: Fix callback and behavior to match passpor
         crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function (err, hashRaw) {
             if (err) {
                 return cb(err);


### PR DESCRIPTION
If some cases, somebody can have custom definition DB, where the salt field can be null.
This cause throwing 
TypeError: Not a buffer
  at pbkdf2 (crypto.js:570:20)
  at Object.exports.pbkdf2 (crypto.js:556:10)

from crypto library.