### PR TITLE
use salt value from options, fixed tests

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -68,7 +68,7 @@ var attachToUser = function (UserSchema, options) {
         if (options.usernameLowerCase) {
             user[options.usernameField] = user[options.usernameField].toLowerCase();
         }
-        if (typeof(next) == 'function') {
+        if (typeof(next) === 'function') {
             next();
         }
     };
@@ -79,24 +79,17 @@ var attachToUser = function (UserSchema, options) {
         }
         
         var self = this;
-
-        crypto.randomBytes(options.saltlen, function (err, buf) {
+		var salt = options.saltField;
+		
+        crypto.pbkdf2(password, salt, options.iterations, options.keylen, function (err, hashRaw) {
             if (err) {
                 return cb(err);
             }
 
-            var salt = buf.toString('hex');
+            self.set(options.hashField, new Buffer(hashRaw, 'binary').toString('hex'));
+            self.set(options.saltField, salt);
 
-            crypto.pbkdf2(password, salt, options.iterations, options.keylen, function (err, hashRaw) {
-                if (err) {
-                    return cb(err);
-                }
-
-                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString('hex'));
-                self.set(options.saltField, salt);
-
-                cb(null, self);
-            });
+            cb(null, self);
         });
     };
     
@@ -123,7 +116,7 @@ var attachToUser = function (UserSchema, options) {
     UserSchema.DAO.prototype.authenticate = function (password, cb) {
         var self = this;
         // TODO: Fix callback and behavior to match passport
-        crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function (err, hashRaw) {
+        crypto.pbkdf2(password, options.saltField, options.iterations, options.keylen, function (err, hashRaw) {
             if (err) {
                 return cb(err);
             }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "mocha": "~1.18.2",
     "jshint": "~2.5.0",
-    "sqlite3": "~2.2.3",
-    "should": "~3.3.1"
+    "should": "~3.3.1",
+	"sqlite3": "^3.0.5"
   }
 }


### PR DESCRIPTION
I have fixed a mismatch between the `salt` usage. **setPassword** is using `salt` from `options` where as **authenticate** is generating the salt via **randomBytes**.

Also I have updated the sqlite3 module for the tests. 
