### PR TITLE
Clear resetPasswordKey field after password reset

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -285,6 +285,7 @@ var attachToUser = function (UserSchema, options) {
             if (user.get(options.resetPasswordKeyField) === resetPasswordKey) {
                 user.setPassword(password, function (err, user) {
                     if (err) { return cb(err); }
+                    user.set(options.resetPasswordKeyField, null);
                     user.save().complete(function (err) {
                         if (err) { return cb(err); }
                         cb(null, user);

--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -68,7 +68,9 @@ var attachToUser = function (UserSchema, options) {
         if (options.usernameLowerCase) {
             user[options.usernameField] = user[options.usernameField].toLowerCase();
         }
-        next();
+        if (typeof(next) == 'function') {
+            next();
+        }
     };
     
     UserSchema.DAO.prototype.setPassword = function (password, cb) {


### PR DESCRIPTION
Pasword reset key needs to be cleared otherwise an attacker just needs to find an old password reset token an can set you password!