### PR TITLE
Changed default key length

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -10,7 +10,7 @@ var defaultAttachOptions = {
     resetPasswordkeylen:  8,
     saltlen:  32,
     iterations:  12000,
-    keylen:  512,
+    keylen:  127,
     usernameField: 'username',
     usernameLowerCase: false,
     activationRequired: false,


### PR DESCRIPTION
The default string length for seqeulize is 255 and having a keylength of 512 will cause it to become truncated to 255 and will fail a comparison when generated again.
