### PR TITLE
Specify error type when throwing an error

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -80,7 +80,9 @@ var attachToUser = function (UserSchema, options) {
 
     UserSchema.Instance.prototype.setPassword = function (password, cb) {
         if (!password) {
-            return cb(new Error(options.missingPasswordError));
+            var err = new Error(options.missingPasswordError);
+            err.name = 'MissingPasswordError';
+            return cb(err);
         }
 
         var self = this;
@@ -194,14 +196,18 @@ var attachToUser = function (UserSchema, options) {
         }
 
         if (!user.get(options.usernameField)) {
-            return cb(new Error(util.format(options.missingUsernameError, options.usernameField)));
+            var err = new Error(util.format(options.missingUsernameError, options.usernameField));
+            err.name = 'MissingUsernameError';
+            return cb(err);
         }
 
         self.findByUsername(user.get(options.usernameField), function (err, existingUser) {
             if (err) { return cb(err); }
 
             if (existingUser) {
-                return cb(new Error(util.format(options.userExistsError, user.get(options.usernameField))));
+                var err = new Error(util.format(options.userExistsError, user.get(options.usernameField)));
+                err.name = 'UserExistsError';
+                return cb(err);
             }
 
             user.setPassword(password, function (err, user) {


### PR DESCRIPTION
Sometimes you need to know which error were thrown, for example, 

```javascript
router.post('/', function(req, res, next) {
    User.register(User.build({username: username}), req.body.password, function(err) {
        if (err) {
            // Handle specific errors customly
            if ('MissingUsernameError' == err.name || 'UserExistsError' == err.name) {
                res.status(400);
                res.render('auth/register', { errorMsg: err.message});
                return;
            }
            // System error (fatal error)
            return next(err);
        }
        ...
   });
});
```

It would be nice to specify that error type.