### PR TITLE
add custom fields insert to db support

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -177,7 +177,7 @@ var attachToUser = function (UserSchema, options) {
         };
     };
 
-    UserSchema.register = function (user, password, cb) {
+    UserSchema.register = function (user, password, cb, customFields = {}) {
         var self = this,
             fields = {};
 
@@ -196,6 +196,9 @@ var attachToUser = function (UserSchema, options) {
         if (!user.get(options.usernameField)) {
             return cb(new Error(util.format(options.missingUsernameError, options.usernameField)));
         }
+
+        //add custom feilds for saving into databaes
+        _.chain(customFields).keys(customFields).map((key) => user[key] = customFields[key]).value();
 
         self.findByUsername(user.get(options.usernameField), function (err, existingUser) {
             if (err) { return cb(err); }


### PR DESCRIPTION
hi,  I did a little code change, this is for support custom fields for registration(ex. email or nickname)

user can do something like this 
```  
Account.register(req.body.username , req.body.password, callbackfun(a, err), {email: req.body.email});
```
to pass custom fields can saving into databases.