### PR TITLE
don't require password on activation

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -228,10 +228,8 @@ var attachToUser = function (UserSchema, options) {
         });
     };
 
-    UserSchema.activate = function (username, password, activationKey, cb) {
-        var self = this;
-        var auth = self.authenticate();
-        auth(username, password, function (err, user, info) {
+    UserSchema.activate = function (username, activationKey, cb) {
+        this.findByUsername(username, function(err, user, info) {
 
             if (err) { return cb(err); }
 


### PR DESCRIPTION
Addresses #17 

Requiring password on activation is something I haven't personally experienced. Typically you send an email with query params of `?email={EMAIL}&key={KEY}` (or similar). I've been using my own fork of PLS in [production](https://jobpigapp.com) ([codebase](https://github.com/lefnire/jobpig)) doing just that. Maybe give Jobpig registration a go to see how it flows, and if this PR is something you wanna merge