### PR TITLE
Upgrade Sequelize, Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   ],
   "dependencies": {
     "passport-local": "~1.0.0",
-    "sequelize": "~3.1.1",
-    "lodash": "~3.8.0"
+    "sequelize": "~3.21.0",
+    "lodash": "~4.6.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
Upgrades lodash for kicks; Sequelize as using this older version was causing errors. I can't remember what they were, but just some package miss-matches while trying to stay up-to-date with other modules. Seems someone else was hitting these snags #24