### PR TITLE
use binary-encoded salt, add digest to options

### DIFF
--- a/lib/passport-local-sequelize.js
+++ b/lib/passport-local-sequelize.js
@@ -6,11 +6,12 @@ var util = require('util'),
 
 // The default option values
 var defaultAttachOptions = {
-    activationkeylen:  8,
-    resetPasswordkeylen:  8,
-    saltlen:  32,
-    iterations:  12000,
-    keylen:  512,
+    activationkeylen: 8,
+    resetPasswordkeylen: 8,
+    saltlen: 32,
+    iterations: 12000,
+    keylen: 512,
+    digest: 'sha1',
     usernameField: 'username',
     usernameLowerCase: false,
     activationRequired: false,
@@ -92,7 +93,7 @@ var attachToUser = function (UserSchema, options) {
 
             var salt = buf.toString('hex');
 
-            crypto.pbkdf2(password, salt, options.iterations, options.keylen, function (err, hashRaw) {
+            crypto.pbkdf2(password, buf, options.iterations, options.keylen, options.digest, function (err, hashRaw) {
                 if (err) {
                     return cb(err);
                 }
@@ -134,7 +135,7 @@ var attachToUser = function (UserSchema, options) {
         }
 
         // TODO: Fix callback and behavior to match passpor
-        crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function (err, hashRaw) {
+        crypto.pbkdf2(password, new Buffer(this.get(options.saltField), 'hex'), options.iterations, options.keylen, options.digest, function (err, hashRaw) {
             if (err) {
                 return cb(err);
             }


### PR DESCRIPTION
1) fixes `DeprecationWarning: crypto.pbkdf2 without specifying a digest is
deprecated. Please specify a digest` by adding a "digest" option with default "sha1"
2) calls `crypto.pbkdf2` with the raw binary salt rather than the "stringified" hex-encoded salt stored to the database, making the treatment of the salt and hash consistent. Previously hex-encoded salt was fed into the `crypto.pbkdf2` function, which is twice as long as the binary salt buffer that the hex string stored in the database represents. **This is a breaking change that will require password resets for any client code using this library to generate and validate password hashes** but means that the hash value will be consistent with the output from `crypto.pbkdf2(password, binaryEncodingOfHexSaltFromDb, ...)`, which I believe to be more consistent with developer expectations about how to interpret these strings.